### PR TITLE
Added config option to toggle showing the slot destroy button

### DIFF
--- a/InspectorDelegateCaller/InspectorDelegateCaller.cs
+++ b/InspectorDelegateCaller/InspectorDelegateCaller.cs
@@ -28,17 +28,6 @@ namespace InspectorDelegateCaller
         [AutoRegisterConfigKey] static ModConfigurationKey<bool> Key_ShowSlotDestroy = new("showSlotDestroy", "show the slot destroy button in inspectors", () => true);
         static ModConfiguration config;
 
-		static List<string> localeStringKeyList;
-		const string FINGERPRINT_STR = "owo ";
-
-		static void maybeMsg(string msg)
-		{
-			if (true)
-			{
-				Msg(msg);
-			}
-		}
-
 		public override void OnEngineInit()
 		{
 			config = GetConfiguration();
@@ -46,42 +35,16 @@ namespace InspectorDelegateCaller
 			harmony.PatchAll();
 		}
 
-        //Type[] argumentTypes, ArgumentType[] argumentVariations
-        [HarmonyPatch(typeof(UIBuilder), "Button", new Type[] { typeof(LocaleString), typeof(IAssetProvider<Sprite>), typeof(Uri), typeof(color), typeof(color) }, new ArgumentType[] { ArgumentType.Ref, ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Ref, ArgumentType.Ref })]
-		class UIBuilder_Button_Patch
-		{
-			static bool Prefix(in LocaleString text, IAssetProvider<Sprite> sprite, Uri spriteUrl, in color tint, in color spriteTint)
-			{
-                //Msg($"UIBuilder Button text: {text}");
-                //if (text.content.Contains(FINGERPRINT_STR))
-                //{
-                //	//local
-                //}
-                maybeMsg($"UIBuilder Button text content: {text.content}");
-                return true;
-			}
-		}
-
 		[HarmonyPatch(typeof(WorkerInspector), "BuildInspectorUI")]
 		class InspectorDelegateCallerPatch
 		{
 			static void Postfix(Worker worker, UIBuilder ui)
 			{
-				try
-				{
-                    maybeMsg($"Worker NiceName: {worker.GetType().GetNiceName("<", ">")}");
-                    maybeMsg($"Worker FullName: {worker.GetType().FullName}");
-                }
-				catch ( Exception e )
-				{
-					Error($"Error when printing NiceName or FullName: {e.Message}");
-				}
                 
                 foreach (var m in worker.GetType().GetMethods(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
 				{
 					var param = m.GetParameters();
                     
-                    //Msg($"MethodInfo: {m.}");
                     if (m.ReturnType == typeof(void))
 					{
 						switch (param.Length)
@@ -89,15 +52,11 @@ namespace InspectorDelegateCaller
 							case 0: //could have some branching mess here. may be marginally faster
 								if (m.CustomAttributes.Any((a) => (a.AttributeType == typeof(SyncMethod) && config.GetValue(Key_Action)) || (a.AttributeType.BaseType == typeof(SyncMethod) && config.GetValue(Key_SubAction))))
 								{
-                                    maybeMsg($"MethodInfo: {m.ToString()}");
                                     LocaleString str = m.Name;
-                                    maybeMsg($"Direct Action Name: {str}");
-                                    //Msg($"Direct Action Content: {str.content}");
 
 									// check for the slot destroy button
                                     if (str == "Destroy" && worker.GetType().FullName == "FrooxEngine.Slot" && config.GetValue(Key_ShowSlotDestroy) == false) break;
 
-									str = FINGERPRINT_STR + str;
 									var b = ui.Button(in str);
 									b.Slot.AttachComponent<ButtonActionTrigger>().OnPressed.Target = (Action)m.CreateDelegate(typeof(Action), worker);
 								}
@@ -105,7 +64,6 @@ namespace InspectorDelegateCaller
 							case 1:
 								if (config.GetValue(Key_ArgAction) && hasSyncMethod(m))
 								{
-                                    maybeMsg($"MethodInfo: {m.ToString()}");
                                     var p = param[0];
 									var pt = p.ParameterType;
 									if (pt.GetInterfaces().Contains(typeof(IWorldElement)))
@@ -117,18 +75,13 @@ namespace InspectorDelegateCaller
 							case 2:
 								if (config.GetValue(Key_Buttons) && isButtonDelegate(param) && hasSyncMethod(m))
 								{
-                                    maybeMsg($"MethodInfo: {m.ToString()}");
                                     LocaleString str = m.Name;
-                                    maybeMsg($"Callable Button Name: {str}");
-                                    //Msg($"Callable Button Content: {str.content}");
-                                    str = FINGERPRINT_STR + str;
                                     var b = ui.Button(in str).Pressed.Target = (ButtonEventHandler)m.CreateDelegate(typeof(ButtonEventHandler), worker);
 								}
 								break;
 							case 3:
 								if (config.GetValue(Key_ArgButtons) && isButtonDelegate(param) && hasSyncMethod(m))
 								{
-                                    maybeMsg($"MethodInfo: {m.ToString()}");
                                     var p = param[2];
 									var pt = p.ParameterType;
 									if (pt.GetInterfaces().Contains(typeof(IWorldElement)))
@@ -150,8 +103,6 @@ namespace InspectorDelegateCaller
 		{
 			ui.HorizontalLayout();
 			LocaleString str = m.Name;
-            maybeMsg($"Action With Arguments Name: {str}");
-            str = FINGERPRINT_STR + str;
             var b = ui.Button(in str);
 			var apt = typeof(Action<>).MakeGenericType(pt);
 			Type t = (isRef ? typeof(CallbackRefArgument<>) : typeof(CallbackValueArgument<>)).MakeGenericType(pt);
@@ -167,8 +118,6 @@ namespace InspectorDelegateCaller
 		{
 			ui.HorizontalLayout();
 			LocaleString str = m.Name;
-            maybeMsg($"Button With Arguments Name: {str}");
-            str = FINGERPRINT_STR + str;
             var b = ui.Button(in str);
 			var bpt = typeof(ButtonEventHandler<>).MakeGenericType(pt);
 			Type t = genType.MakeGenericType(pt);

--- a/InspectorDelegateCaller/InspectorDelegateCaller.cs
+++ b/InspectorDelegateCaller/InspectorDelegateCaller.cs
@@ -25,8 +25,8 @@ namespace InspectorDelegateCaller
 		[AutoRegisterConfigKey] static ModConfigurationKey<bool> Key_Buttons = new("buttons", "show callable buttons in inspectors", () => false);
 		[AutoRegisterConfigKey] static ModConfigurationKey<bool> Key_ArgButtons = new("argButtons", "show any button with arguments in inspectors", () => true);
 
-        [AutoRegisterConfigKey] static ModConfigurationKey<bool> Key_ShowSlotDestroy = new("showSlotDestroy", "show the slot destroy button in inspectors", () => true);
-        static ModConfiguration config;
+		[AutoRegisterConfigKey] static ModConfigurationKey<bool> Key_ShowSlotDestroy = new("showSlotDestroy", "show the slot destroy button in inspectors", () => true);
+		static ModConfiguration config;
 
 		public override void OnEngineInit()
 		{
@@ -40,22 +40,22 @@ namespace InspectorDelegateCaller
 		{
 			static void Postfix(Worker worker, UIBuilder ui)
 			{
-                
-                foreach (var m in worker.GetType().GetMethods(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+
+				foreach (var m in worker.GetType().GetMethods(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
 				{
 					var param = m.GetParameters();
-                    
-                    if (m.ReturnType == typeof(void))
+
+					if (m.ReturnType == typeof(void))
 					{
 						switch (param.Length)
 						{
 							case 0: //could have some branching mess here. may be marginally faster
 								if (m.CustomAttributes.Any((a) => (a.AttributeType == typeof(SyncMethod) && config.GetValue(Key_Action)) || (a.AttributeType.BaseType == typeof(SyncMethod) && config.GetValue(Key_SubAction))))
 								{
-                                    LocaleString str = m.Name;
+									LocaleString str = m.Name;
 
 									// check for the slot destroy button
-                                    if (str == "Destroy" && worker.GetType().FullName == "FrooxEngine.Slot" && config.GetValue(Key_ShowSlotDestroy) == false) break;
+									if (str == "Destroy" && worker.GetType().FullName == "FrooxEngine.Slot" && config.GetValue(Key_ShowSlotDestroy) == false) break;
 
 									var b = ui.Button(in str);
 									b.Slot.AttachComponent<ButtonActionTrigger>().OnPressed.Target = (Action)m.CreateDelegate(typeof(Action), worker);
@@ -64,7 +64,7 @@ namespace InspectorDelegateCaller
 							case 1:
 								if (config.GetValue(Key_ArgAction) && hasSyncMethod(m))
 								{
-                                    var p = param[0];
+									var p = param[0];
 									var pt = p.ParameterType;
 									if (pt.GetInterfaces().Contains(typeof(IWorldElement)))
 										actionCallbackwitharg(true, worker, ui, m, p, pt);
@@ -75,14 +75,14 @@ namespace InspectorDelegateCaller
 							case 2:
 								if (config.GetValue(Key_Buttons) && isButtonDelegate(param) && hasSyncMethod(m))
 								{
-                                    LocaleString str = m.Name;
-                                    var b = ui.Button(in str).Pressed.Target = (ButtonEventHandler)m.CreateDelegate(typeof(ButtonEventHandler), worker);
+									LocaleString str = m.Name;
+									var b = ui.Button(in str).Pressed.Target = (ButtonEventHandler)m.CreateDelegate(typeof(ButtonEventHandler), worker);
 								}
 								break;
 							case 3:
 								if (config.GetValue(Key_ArgButtons) && isButtonDelegate(param) && hasSyncMethod(m))
 								{
-                                    var p = param[2];
+									var p = param[2];
 									var pt = p.ParameterType;
 									if (pt.GetInterfaces().Contains(typeof(IWorldElement)))
 										buttonCallbackwitharg(typeof(ButtonRefRelay<>), worker, ui, m, p, pt);
@@ -103,7 +103,7 @@ namespace InspectorDelegateCaller
 		{
 			ui.HorizontalLayout();
 			LocaleString str = m.Name;
-            var b = ui.Button(in str);
+			var b = ui.Button(in str);
 			var apt = typeof(Action<>).MakeGenericType(pt);
 			Type t = (isRef ? typeof(CallbackRefArgument<>) : typeof(CallbackValueArgument<>)).MakeGenericType(pt);
 			var c = b.Slot.AttachComponent(t);
@@ -118,7 +118,7 @@ namespace InspectorDelegateCaller
 		{
 			ui.HorizontalLayout();
 			LocaleString str = m.Name;
-            var b = ui.Button(in str);
+			var b = ui.Button(in str);
 			var bpt = typeof(ButtonEventHandler<>).MakeGenericType(pt);
 			Type t = genType.MakeGenericType(pt);
 			var c = b.Slot.AttachComponent(t);

--- a/InspectorDelegateCaller/InspectorDelegateCaller.cs
+++ b/InspectorDelegateCaller/InspectorDelegateCaller.cs
@@ -6,9 +6,6 @@ using NeosModLoader;
 using FrooxEngine;
 using FrooxEngine.UIX;
 using BaseX;
-using static System.Net.Mime.MediaTypeNames;
-using System.Text;
-using System.Collections.Generic;
 
 namespace InspectorDelegateCaller
 {

--- a/InspectorDelegateCaller/InspectorDelegateCaller.csproj
+++ b/InspectorDelegateCaller/InspectorDelegateCaller.csproj
@@ -13,7 +13,7 @@
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
     <ProjectGuid>{0322B2EF-7452-479D-BAE2-FCAB75033337}</ProjectGuid>
-	<LangVersion>10</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,16 +34,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\packages\Lib.Harmony.2.1.1\lib\net45\0Harmony.dll</HintPath>
+      <HintPath>G:\Neos\app\nml_libs\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="BaseX">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Neos_Data\Managed\BaseX.dll</HintPath>
-	</Reference>
+      <HintPath>G:\Neos\app\Neos_Data\Managed\BaseX.dll</HintPath>
+    </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Neos_Data\Managed\FrooxEngine.dll</HintPath>
+      <HintPath>G:\Neos\app\Neos_Data\Managed\FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="NeosModLoader">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Libraries\NeosModLoader.dll</HintPath>
+      <HintPath>G:\Neos\app\Libraries\NeosModLoader.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -56,6 +56,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)\$(TargetFileName)" "C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods\"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)\$(TargetFileName)" "G:\Neos\app\nml_mods\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/InspectorDelegateCaller/InspectorDelegateCaller.csproj
+++ b/InspectorDelegateCaller/InspectorDelegateCaller.csproj
@@ -13,7 +13,7 @@
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
     <ProjectGuid>{0322B2EF-7452-479D-BAE2-FCAB75033337}</ProjectGuid>
-    <LangVersion>10</LangVersion>
+	<LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,16 +34,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>G:\Neos\app\nml_libs\0Harmony.dll</HintPath>
+      <HintPath>..\packages\Lib.Harmony.2.1.1\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="BaseX">
-      <HintPath>G:\Neos\app\Neos_Data\Managed\BaseX.dll</HintPath>
-    </Reference>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Neos_Data\Managed\BaseX.dll</HintPath>
+	</Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>G:\Neos\app\Neos_Data\Managed\FrooxEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Neos_Data\Managed\FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="NeosModLoader">
-      <HintPath>G:\Neos\app\Libraries\NeosModLoader.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Libraries\NeosModLoader.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -56,6 +56,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)\$(TargetFileName)" "G:\Neos\app\nml_mods\"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)\$(TargetFileName)" "C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods\"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
It is way too easy to accidentally click this button while trying to change the transform of a slot. Even worse is that the destroy button is not undoable, so if you click it you cannot get the slot back unless you saved it. Currently the way to avoid this button is to disable all direct action buttons, but you probably lose access to other useful buttons by doing that. Therefore an ideal solution is the introduction of a config option which can toggle showing the destroy button.